### PR TITLE
Add MiniMax H3 1K prompt dataset to the caption-level datasets

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,6 +168,7 @@ If you find our survey is useful in your research or applications, please consid
 
 
 
+| [MiniMax H3 1K Prompt Dataset](https://neta.art/use-cases/en/h3-1000-prompt-list) | [![Dataset](https://img.shields.io/badge/Dataset-HuggingFace-blue?logo=huggingface)](https://huggingface.co/datasets/ostris/minimax_h3_1k) | [![Star](https://img.shields.io/github/stars/yangzhou-chaofan/minimax-h3-1000-prompts.svg?style=social&label=Star)](https://github.com/yangzhou-chaofan/minimax-h3-1000-prompts) | [![Website](https://img.shields.io/badge/Website-9cf)](https://neta.art/use-cases/en/h3-1000-prompt-list) | 2026 |
 
 ### Category-level
 


### PR DESCRIPTION
Alongside the video-text datasets listed in the Caption-level table, this curated 1K text-to-video prompt dataset adds a prompt-gallery resource: 3-field prompt-structure anatomy, 10 hand-picked reusable prompts, and an H3 vs. peer model comparison.\n\nLinks:\n- Interactive atlas of all 1,000 H3 clips: https://neta.art/use-cases/en/h3-1000-prompt-list\n- Curated index repo: https://github.com/yangzhou-chaofan/minimax-h3-1000-prompts\n- Original dataset (ostris/minimax_h3_1k): https://huggingface.co/datasets/ostris/minimax_h3_1k